### PR TITLE
Removes dependency on Medea package

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,21 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "Medea",
-        "repositoryURL": "https://github.com/jemmons/Medea.git",
-        "state": {
-          "branch": null,
-          "revision": "806bfb36c4f1e12b365c8b4108a834f35a614c44",
-          "version": "5.0.0"
-        }
-      },
-      {
         "package": "Perfidy",
         "repositoryURL": "https://github.com/jemmons/Perfidy.git",
         "state": {
           "branch": null,
-          "revision": "77daae0eaa91159849695c079d54ecc61bc08d26",
-          "version": "5.0.0"
+          "revision": "ef21739e7526ccc087b2054b7cf0d04c1e63bba9",
+          "version": "6.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -12,16 +12,15 @@ let package = Package(
       targets: ["SessionArtist"]),
   ],
   dependencies: [
-    // Dependencies declare other packages that this package depends on.
-    .package(url: "https://github.com/jemmons/Medea.git", from: "5.0.0"),
-    .package(url: "https://github.com/jemmons/Perfidy.git", from: "5.0.0"),
+    // Note that Perfidy is test-only.
+    .package(url: "https://github.com/jemmons/Perfidy.git", from: "6.0.0"),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.
     // Targets can depend on other targets in this package, and on products in packages which this package depends on.
     .target(
       name: "SessionArtist",
-      dependencies: ["Medea"]),
+      dependencies: []),
     .testTarget(
       name: "SessionArtistTests",
       dependencies: ["SessionArtist", "Perfidy"]),

--- a/Sources/SessionArtist/Endpoint.swift
+++ b/Sources/SessionArtist/Endpoint.swift
@@ -70,7 +70,7 @@ private extension Endpoint {
   
   func url(from baseURL: URL) -> URL {
     guard var comps = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
-      fatalError("Problem resolving against base URL")
+      preconditionFailure("Problem resolving against base URL")
     }
     
     comps.appendPathComponent(path)
@@ -80,7 +80,7 @@ private extension Endpoint {
     }
     
     guard let url = comps.url else {
-      fatalError("Problem with leading “/” in path.")
+      preconditionFailure("Problem with leading “/” in path.")
     }
     
     return url

--- a/Sources/SessionArtist/Errors.swift
+++ b/Sources/SessionArtist/Errors.swift
@@ -2,16 +2,33 @@ import Foundation
 
 
 
-public enum HTTPError: LocalizedError {
-  case notHTTP, unknownCode(Int)
+public enum Error: LocalizedError {
+  case notHTTP, unknownStatusCode(Int), notJSONObject, notJSONArray, invalidJSONObject
   
   
   public var errorDescription: String? {
     switch self {
     case .notHTTP:
       return "The response was not in the expected format."
-    case .unknownCode(let code):
+    case .unknownStatusCode(let code):
       return "The code “\(String(code))” is not a valid HTTP status."
+    case .notJSONObject:
+      return "Expected an object, but got some other JSON type."
+    case .notJSONArray:
+      return "Expected an array, but got some other JSON type."
+    case .invalidJSONObject:
+      return "The given object is not valid JSON."
+
+    }
+  }
+  
+  
+  public var failureReason: String? {
+    switch self {
+    case .notHTTP, .unknownStatusCode:
+      return "HTTP Error"
+    case .notJSONObject, .notJSONArray, .invalidJSONObject:
+      return "JSON Error"
     }
   }
 }

--- a/Sources/SessionArtist/Host.swift
+++ b/Sources/SessionArtist/Host.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Medea
 
 
 

--- a/Sources/SessionArtist/Request.swift
+++ b/Sources/SessionArtist/Request.swift
@@ -1,14 +1,12 @@
 import Foundation
-import Medea
 
 
 
 public class Request {
-  public typealias DataCompletionHandler = (Result<(code: HTTPStatusCode, contentType: String?, body: Data), Error>) -> Void
-  public typealias JSONCompletionHandler = (Result<(code: HTTPStatusCode, json: AnyJSON), Error>) -> Void
-  public typealias JSONObjectCompletionHandler = (Result<(code: HTTPStatusCode, json: JSONObject), Error>) -> Void
-  public typealias JSONArrayCompletionHandler = (Result<(code: HTTPStatusCode, json: JSONArray), Error>) -> Void
-  public typealias TextCompletionHandler = (Result<(code: HTTPStatusCode, text: String), Error>) -> Void
+  public typealias DataCompletionHandler = (Result<(code: HTTPStatusCode, contentType: String?, body: Data), Swift.Error>) -> Void
+  public typealias JSONObjectCompletionHandler = (Result<(code: HTTPStatusCode, json: JSONObject), Swift.Error>) -> Void
+  public typealias JSONArrayCompletionHandler = (Result<(code: HTTPStatusCode, json: JSONArray), Swift.Error>) -> Void
+  public typealias TextCompletionHandler = (Result<(code: HTTPStatusCode, text: String), Swift.Error>) -> Void
 
   
   private let session: URLSession
@@ -16,7 +14,7 @@ public class Request {
   public var urlRequest: URLRequest {
     // Note the request we actually want is the one that will be sent by the session. That is: `request` merged with the properties of `session` — particularly the `httpAdditionalHeaders` of the `session`'s config.
     guard var newRequest = session.dataTask(with: request).currentRequest else {
-      fatalError("Couldn't retrieve request from task explicitly created with it.")
+      preconditionFailure("Couldn’t retrieve request from task explicitly created with it.")
     }
 
     // There's a bug in iOS 13/Catalina that doesn't copy the session's `httpAdditionalHeaders` over to a request until the request's task has been `resume`'d. So we have to manually merge the headers, instead.
@@ -46,17 +44,12 @@ public extension Request {
     
     
   @discardableResult
-  func json(_ completion: @escaping JSONCompletionHandler) -> URLSessionTask {
-    return data(Helper.dataHandler(from: completion) {
-      return try JSONHelper.anyJSON(from: $0)
-    })
-  }
-  
-  
-  @discardableResult
   func jsonObject(_ completion: @escaping JSONObjectCompletionHandler) -> URLSessionTask {
     return data(Helper.dataHandler(from: completion) {
-      return try JSONHelper.jsonObject(from: $0)
+      guard let jsonObject = try JSONSerialization.jsonObject(with: $0, options: []) as? JSONObject else {
+        throw Error.notJSONObject
+      }
+      return jsonObject
     })
   }
 
@@ -64,7 +57,10 @@ public extension Request {
   @discardableResult
   func jsonArray(_ completion: @escaping JSONArrayCompletionHandler) -> URLSessionTask {
     return data(Helper.dataHandler(from: completion) {
-      return try JSONHelper.jsonArray(from: $0)
+      guard let jsonArray = try JSONSerialization.jsonObject(with: $0, options: []) as? JSONArray else {
+        throw Error.notJSONArray
+      }
+      return jsonArray
     })
   }
 }
@@ -80,18 +76,18 @@ private extension Request {
         
       case let (d?, r?, _):
         guard let httpResponse = r as? HTTPURLResponse else {
-          completion(.failure(HTTPError.notHTTP))
+          completion(.failure(Error.notHTTP))
           return
         }
         guard let code = HTTPStatusCode(rawValue: httpResponse.statusCode) else {
-          completion(.failure(HTTPError.unknownCode(httpResponse.statusCode)))
+          completion(.failure(Error.unknownStatusCode(httpResponse.statusCode)))
           return
         }
         completion(.success((code: code, contentType: Helper.contentType(from: httpResponse.allHeaderFields), body: d)))
         
       default:
         // Either there was data and no response, response and no data, or no data, response, or error. All of which should be impossible.
-        fatalError("URLSession API is broken.")
+        preconditionFailure("URLSession API is broken.")
       }
     }
     task.resume()
@@ -112,9 +108,9 @@ private enum Helper {
   }
 
 
-  static func dataHandler<T>(from handler: @escaping (Result<(code: HTTPStatusCode, json: T), Error>) -> Void, factory: @escaping (Data) throws -> T) -> Request.DataCompletionHandler {
-    return { (res: Result<(code: HTTPStatusCode, contentType: String?, body: Data), Error>) -> Void in
-      let jsonResult = res.flatMap { code, _, body -> Result<(code: HTTPStatusCode, json: T), Error> in
+  static func dataHandler<T>(from handler: @escaping (Result<(code: HTTPStatusCode, json: T), Swift.Error>) -> Void, factory: @escaping (Data) throws -> T) -> Request.DataCompletionHandler {
+    return { (res: Result<(code: HTTPStatusCode, contentType: String?, body: Data), Swift.Error>) -> Void in
+      let jsonResult = res.flatMap { code, _, body -> Result<(code: HTTPStatusCode, json: T), Swift.Error> in
         do {
           return .success((code: code, json: try factory(body)))
         } catch {

--- a/Sources/SessionArtist/Types.swift
+++ b/Sources/SessionArtist/Types.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+
+public typealias JSONObject = [String: Any]
+public typealias JSONArray = [Any]

--- a/Sources/SessionArtist/ValidJSONObject.swift
+++ b/Sources/SessionArtist/ValidJSONObject.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+
+
+public struct ValidJSONObject {
+  public let value: JSONObject
+  
+  
+  public init(_ jsonObject: JSONObject) throws {
+    guard JSONSerialization.isValidJSONObject(jsonObject) else {
+      throw Error.invalidJSONObject
+    }
+    value = jsonObject
+  }
+}

--- a/Tests/SessionArtistTests/DeleteTests.swift
+++ b/Tests/SessionArtistTests/DeleteTests.swift
@@ -2,7 +2,6 @@ import Foundation
 import XCTest
 import SessionArtist
 import Perfidy
-import Medea
 
 
 
@@ -21,7 +20,7 @@ class DeleteTests: XCTestCase {
       }
       
       fakeHost.delete("/test").data { res in
-        if case .success(.ok, _, _) = res {
+        if case .success((.ok, _, _)) = res {
           expectedResponse.fulfill()
         }
       }
@@ -42,7 +41,7 @@ class DeleteTests: XCTestCase {
       }
       
       fakeHost.delete("/test", headers: [.accept: "foobar"]).data { res in
-        if case .success(.ok, _, _) = res {
+        if case .success((.ok, _, _)) = res {
           expectedResponse.fulfill()
         }
       }

--- a/Tests/SessionArtistTests/EndpointConvertibleTests.swift
+++ b/Tests/SessionArtistTests/EndpointConvertibleTests.swift
@@ -2,7 +2,6 @@ import Foundation
 import XCTest
 import SessionArtist
 import Perfidy
-import Medea
 
 
 

--- a/Tests/SessionArtistTests/EndpointTests.swift
+++ b/Tests/SessionArtistTests/EndpointTests.swift
@@ -1,7 +1,6 @@
 import Foundation
 import XCTest
 import SessionArtist
-import Medea
 
 
 

--- a/Tests/SessionArtistTests/GetTests.swift
+++ b/Tests/SessionArtistTests/GetTests.swift
@@ -45,7 +45,7 @@ private extension GetTests {
       }
       
       fakeHost.get(path, query: query, headers: headers).data { res in
-        if case .success(.ok, _, _) = res {
+        if case .success((.ok, _, _)) = res {
           expectedResponse.fulfill()
         }
       }

--- a/Tests/SessionArtistTests/ParamsTests.swift
+++ b/Tests/SessionArtistTests/ParamsTests.swift
@@ -1,7 +1,6 @@
 import Foundation
 import XCTest
 import SessionArtist
-import Medea
 
 
 

--- a/Tests/SessionArtistTests/PostTests.swift
+++ b/Tests/SessionArtistTests/PostTests.swift
@@ -2,7 +2,6 @@ import Foundation
 import XCTest
 import SessionArtist
 import Perfidy
-import Medea
 
 
 
@@ -48,7 +47,7 @@ private extension PostTests {
       
       let validJSON = try! ValidJSONObject(json)
       fakeHost.post(path, json: validJSON, headers: headers).data { res in
-        if case .success(.ok, _, _) = res {
+        if case .success((.ok, _, _)) = res {
           expectedResponse.fulfill()
         }
       }

--- a/Tests/SessionArtistTests/PutTests.swift
+++ b/Tests/SessionArtistTests/PutTests.swift
@@ -2,7 +2,6 @@ import Foundation
 import XCTest
 import SessionArtist
 import Perfidy
-import Medea
 
 
 
@@ -48,7 +47,7 @@ private extension PutTests {
       
       let validJSON = try! ValidJSONObject(json)
       fakeHost.put(path, json: validJSON, headers: headers).data { res in
-        if case .success(.ok, _, _) = res {
+        if case .success((.ok, _, _)) = res {
           expectedResponse.fulfill()
         }
       }

--- a/Tests/SessionArtistTests/RequestTests.swift
+++ b/Tests/SessionArtistTests/RequestTests.swift
@@ -118,7 +118,7 @@ private extension RequestTests {
       }
       
       fakeHost.request(endpoint).data { res in
-        if case .success(.ok, _, _) = res {
+        if case .success((.ok, _, _)) = res {
           expectedResponse.fulfill()
         }
       }

--- a/Tests/SessionArtistTests/ResponseTests.swift
+++ b/Tests/SessionArtistTests/ResponseTests.swift
@@ -17,32 +17,12 @@ class ResponseTests: XCTestCase {
       server.add("/test", response: ["foo": "bar"])
       
       fakeHost.request(endpoint).data { res in
-        guard case let .success(status, contentType, data) = res else {
+        guard case let .success((status, contentType, data)) = res else {
           fatalError("not a success")
         }
         XCTAssertEqual(status, .ok)
         XCTAssertEqual(contentType, "application/json")
         XCTAssertEqual(String(data: data, encoding: .utf8), "{\"foo\":\"bar\"}")
-        expectedResponse.fulfill()
-      }
-      
-      wait(for: [expectedResponse], timeout: 1)
-    }
-  }
-  
-  
-  func testAnyJSON() {
-    let expectedResponse = expectation(description: "waiting for response")
-    
-    FakeServer.runWith { server in
-      server.add("/test", response: ["foo": "bar"])
-      
-      fakeHost.request(endpoint).json { res in
-        guard case let .success(status, .object(json)) = res else {
-          fatalError("not a success")
-        }
-        XCTAssertEqual(status, .ok)
-        XCTAssertEqual(json as! [String: String], ["foo": "bar"])
         expectedResponse.fulfill()
       }
       
@@ -58,7 +38,7 @@ class ResponseTests: XCTestCase {
       server.add("/test", response: ["foo": "bar"])
       
       fakeHost.request(endpoint).jsonObject { res in
-        guard case let .success(status, json) = res else {
+        guard case let .success((status, json)) = res else {
           fatalError("not a success")
         }
         XCTAssertEqual(status, .ok)
@@ -96,7 +76,7 @@ class ResponseTests: XCTestCase {
       server.add("/test", response: try! Response(jsonArray:["foo", "bar"]))
       
       fakeHost.request(endpoint).jsonArray { res in
-        guard case let .success(status, json) = res else {
+        guard case let .success((status, json)) = res else {
           fatalError("not a success")
         }
         XCTAssertEqual(status, .ok)


### PR DESCRIPTION
Medea was primarily being used for it’s `AnyJSON` type’s ability to handle any JSON fragment. But it’s not strictly legal (and has never been a good idea) to return anything but an object or array in response to a JSON request. And arrays and object are easy to parse without Medea’s help via `JSONSerlialization` (and really, even this minimal amount of JSON parsing is less common now that `Codable` is a thing and decoding is happening at the callsite. Everyone just wants `Data`).

Of the rest of its features, the `ValidJSONObject` type is the only that was really being used, and that's trivial to implement internally to SessionArtist.

Breaking Changes:
* `Request.json(_:)` has been removed.
* `Medea` types like `JSONObject`, `JSONArray`, and `ValidJSONObject` are now directly under the `SessionArtist` namespace.
* The same events that threw errors that threw Medea-originated errors still throw errors. But now they're of the `SessionArtist.Error` type.
* Updated `Package` file to tools version 5.2. This should mean dependencies only used for testing (like `Perfidy`) will no longer be pulled by consumers.