### PR TITLE
Moves SessionArtist.Error to SessionArtist.APIError

### DIFF
--- a/Sources/SessionArtist/APIError.swift
+++ b/Sources/SessionArtist/APIError.swift
@@ -2,7 +2,7 @@ import Foundation
 
 
 
-public enum Error: LocalizedError {
+public enum APIError: LocalizedError {
   case notHTTP, unknownStatusCode(Int), notJSONObject, notJSONArray, invalidJSONObject
   
   

--- a/Sources/SessionArtist/Params.swift
+++ b/Sources/SessionArtist/Params.swift
@@ -80,7 +80,7 @@ private enum Helper {
       
     case let array as JSONArray:
       guard let somePrefix = prefix else {
-        throw Error.notJSONObject
+        throw APIError.notJSONObject
       }
       try array.forEach { element in
         items.append(contentsOf: try makeQuery(from: element, prefix: somePrefix + "[]"))
@@ -88,7 +88,7 @@ private enum Helper {
       
     default:
       guard let somePrefix = prefix else {
-        throw Error.notJSONObject
+        throw APIError.notJSONObject
       }
       items.append(URLQueryItem(name: somePrefix, value: String(describing: jsonValue)))
     }

--- a/Sources/SessionArtist/ValidJSONObject.swift
+++ b/Sources/SessionArtist/ValidJSONObject.swift
@@ -8,7 +8,7 @@ public struct ValidJSONObject {
   
   public init(_ jsonObject: JSONObject) throws {
     guard JSONSerialization.isValidJSONObject(jsonObject) else {
-      throw Error.invalidJSONObject
+      throw APIError.invalidJSONObject
     }
     value = jsonObject
   }


### PR DESCRIPTION
Having an `Error` type at the top level of the module was causing random conflicts in other projects, and was probably always a bad idea given the identically named `Error` protocol.